### PR TITLE
Update to Gnome 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/ente76/guillotine/",
     "settings-schema": "org.gnome.shell.extensions.guillotine",
     "shell-version": [
-        "40"
+        "40",
+        "41"
     ]
 }


### PR DESCRIPTION
Add support of Gnome 41.
Using `guillotine` with it for a month already, works as a charm.